### PR TITLE
fix eslint config (hide false errors on windows linebreaks)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,9 +5,7 @@ module.exports = {
     node: true,
     mocha: true,
   },
-  extends: [
-    'airbnb-base',
-  ],
+  extends: ['airbnb-base'],
   globals: {
     Atomics: 'readonly',
     SharedArrayBuffer: 'readonly',
@@ -20,5 +18,6 @@ module.exports = {
     'no-plusplus': 'off',
     'func-names': 'off',
     'space-before-function-paren': 'off',
+    'linebreak-style': 0,
   },
 };


### PR DESCRIPTION
The current ESLint configuration causes false error messages to appear on the Windows system: `Expected linebreaks to be 'LF' but found 'CRLF'.`.

This PR fixes the ESLint config by eliminating checks for line endings.