### PR TITLE
[fix-2] ListNode stub is changed to spy

### DIFF
--- a/test/14-queue-tests.js
+++ b/test/14-queue-tests.js
@@ -2,12 +2,13 @@ const proxyquire = require('proxyquire');
 const sinon = require('sinon');
 const assert = require('assert');
 it.optional = require('../extensions/it-optional');
+const ListNode = require('../extensions/list-node');
 
 describe('14-queue', () => {
   const sandbox = sinon.createSandbox();
-  const ListNodeStub = sandbox.stub();
+  const ListNodeSpy = sandbox.spy(ListNode);
   const Queue = proxyquire('../src/14-queue', {
-    '../extensions/list-node': ListNodeStub,
+    '../extensions/list-node': ListNodeSpy,
   });
 
   afterEach(() => {
@@ -27,6 +28,6 @@ describe('14-queue', () => {
     const queue = new Queue();
     assert.doesNotThrow(() => queue.enqueue(5));
     assert.strictEqual(queue.dequeue(), 5);
-    assert.strictEqual(ListNodeStub.called, true);
+    assert.strictEqual(ListNodeSpy.called, true);
   });
 });


### PR DESCRIPTION
Приветствую.

На текущий момент в тестах к заданию 14-queue конструктор ListNode подменяется заглушкой. Из-за этого тест падает в случаях, когда решение основано на передаче в данный конструктор значения для ноды очереди.

Пруфы, что проблемы не только у меня: [1](https://discord.com/channels/516715744646660106/828911791504490506/828949979611398215), [2](https://discord.com/channels/516715744646660106/828911791504490506/828954305557561354). Также, если посмотреть работы уже сдавших задание студентов, то будет видно, что они все так или иначе используют обходные решения: или в дополнение к основной очереди (основанной на ListNode) заводят ещё одну, или не используют конструктор, а задают значение для ноды напрямую.

Данный фикс чинит тесты, заменяя `sinon.stab()` на обёртку `sinon.spy()`, тем самым сохраняя изначальный функционал конструктора.

До фикса:
![image](https://user-images.githubusercontent.com/6975490/113826979-712db000-978b-11eb-8e10-8a8e380e42c1.png)

После фикса (если не подключить ListNode):
![image](https://user-images.githubusercontent.com/6975490/113827152-a4703f00-978b-11eb-9f1a-978681c47dd7.png)

После фикса (если подключить ListNode, как указано в задании):
![image](https://user-images.githubusercontent.com/6975490/113827244-be118680-978b-11eb-9078-61664deecf50.png)
