### PR TITLE
[fix-4] corrected the typo in jsdoc 08-remove-from-list.js

### DIFF
--- a/src/08-remove-from-list.js
+++ b/src/08-remove-from-list.js
@@ -7,7 +7,7 @@
  * @return {List}
  *
  * @example
- * For l = [3, 1, 2, 3, 4, 5] and l = 3,
+ * For l = [3, 1, 2, 3, 4, 5] and k = 3,
  * the output should be [1, 2, 4, 5]
  *
  * Singly - linked lists are already defined with this interface


### PR DESCRIPTION
corrected a typo, replaced "l" with "k".